### PR TITLE
fix(search): Return 400 when search term is not found

### DIFF
--- a/src/main/java/com/gsearch/api/SearchController.java
+++ b/src/main/java/com/gsearch/api/SearchController.java
@@ -13,17 +13,20 @@ public class SearchController {
 
 	/**
 	 *
-	 * @param searchterm
+	 * @param searchTerm
 	 * @return
 	 * @throws JsonProcessingException
 	 */
 	@GetMapping(value = "/search")
-	public ResponseEntity<?> search(@RequestParam String searchterm) throws JsonProcessingException {
+	public ResponseEntity<?> search(@RequestParam String searchTerm) {
 		List<Data> searchResponse = testData();
-		Optional<Data> matchingObject = searchResponse.stream().filter(p -> p.getTitle().equals(searchterm))
+		Optional<Data> matchingObject = searchResponse.stream().filter(p -> p.getTitle().equals(searchTerm))
 				.findFirst();
-		Data responseData = matchingObject.get();
-		return ResponseEntity.ok().body(responseData);
+		if (matchingObject.isPresent()) {
+			return ResponseEntity.ok().body(matchingObject.get());
+		} else {
+			return ResponseEntity.noContent().build();
+		}
 	}
 
 	public List<Data> testData() {


### PR DESCRIPTION
## Issue ID
#17 
## Summary
Return 400 when search term is not found
## Checklist

- [x] Have you added an summary of what your changes do and why you'd like us to include them?
- [x] Which changes caused this issue / Root Cause.
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the current behavior, and the steps to reproduce the issue?
When there are no result for the given keyword, API returns 500 
### What is the expected behavior?
When there are no result, then the API should return 204 - No content.
### How does this PR fix the problem, Screenshot Please?

```
curl --location --request GET 'http://localhost:8080/search?searchTerm=translate' \
--header 'accept: */*'
```

![image](https://user-images.githubusercontent.com/4453880/157847572-233e6d52-b4b4-4775-80de-8328f0704194.png)
