### PR TITLE
fix(search-results): Return list of results content

### DIFF
--- a/src/main/java/com/gsearch/api/SearchController.java
+++ b/src/main/java/com/gsearch/api/SearchController.java
@@ -13,17 +13,20 @@ public class SearchController {
 
 	/**
 	 *
-	 * @param searchterm
+	 * @param searchTerm
 	 * @return
 	 * @throws JsonProcessingException
 	 */
 	@GetMapping(value = "/search")
-	public ResponseEntity<?> search(@RequestParam String searchterm) throws JsonProcessingException {
+	public ResponseEntity<?> search(@RequestParam String searchTerm) {
 		List<Data> searchResponse = testData();
-		Optional<Data> matchingObject = searchResponse.stream().filter(p -> p.getTitle().equals(searchterm))
+		Optional<Data> matchingObject = searchResponse.stream().filter(p -> p.getTitle().equals(searchTerm))
 				.findFirst();
-		Data responseData = matchingObject.get();
-		return ResponseEntity.ok().body(responseData);
+		if (matchingObject.isPresent()) {
+			return ResponseEntity.ok().body(matchingObject.get());
+		} else {
+			return ResponseEntity.noContent().build();
+		}
 	}
 
 	public List<Data> testData() {

--- a/src/main/java/com/gsearch/api/SearchController.java
+++ b/src/main/java/com/gsearch/api/SearchController.java
@@ -1,6 +1,7 @@
 package com.gsearch.api;
 
 import java.util.*;
+import java.util.stream.*;
 
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
@@ -20,10 +21,10 @@ public class SearchController {
 	@GetMapping(value = "/search")
 	public ResponseEntity<?> search(@RequestParam String searchTerm) {
 		List<Data> searchResponse = testData();
-		Optional<Data> matchingObject = searchResponse.stream().filter(p -> p.getTitle().equals(searchTerm))
-				.findFirst();
-		if (matchingObject.isPresent()) {
-			return ResponseEntity.ok().body(matchingObject.get());
+		List<Data> contentList = searchResponse.stream().filter(p -> p.getTitle().equals(searchTerm))
+				.collect(Collectors.toList());
+		if (!contentList.isEmpty()) {
+			return ResponseEntity.ok().body(contentList);
 		} else {
 			return ResponseEntity.noContent().build();
 		}
@@ -31,63 +32,24 @@ public class SearchController {
 
 	public List<Data> testData() {
 		List<Data> searchResponse = new ArrayList<>();
-		Data obj = new Data();
-		obj.setTitle("google");
-		obj.setContent(
-				"Search the world's information, including webpages, images, videos and more. Google has many special features to help you find exactly what you're looking");
-		obj.setUrl("www.google.com");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("facebook");
-		obj.setContent(
-				"Create an account or log into Facebook. Connect with friends, family and other people you know. Share photos and videos, send messages and get updates.");
-		obj.setUrl("https://www.facebook.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("whatsapp web");
-		obj.setContent("Quickly send and receive WhatsApp messages right from your computer");
-		obj.setUrl("https://web.whatsapp.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("whatsapp web");
-		obj.setContent("Quickly send and receive WhatsApp messages right from your computer");
-		obj.setUrl("https://web.whatsapp.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("youtube");
-		obj.setContent(
-				"Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.");
-		obj.setUrl("https://www.youtube.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("gmail");
-		obj.setContent("No information is available for this page.");
-		obj.setUrl("https://mail.google.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("amazon");
-		obj.setContent(
-				"Free shipping on millions of items. Get the best of Shopping and Entertainment with Prime. Enjoy low prices and great deals on the largest selection");
-		obj.setUrl("https://www.amazon.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("google translate");
-		obj.setContent(
-				"Google's free service instantly translates words, phrases, and web pages between English and over 100 other languages.");
-		obj.setUrl("https://translate.google.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("tranductor");
-		obj.setContent(
-				"Este servicio gratuito de Google traduce instantáneamente palabras, frases y páginas web del español a más de 100 idiomas y viceversa.");
-		obj.setUrl("https://translate.google.com/");
-		searchResponse.add(obj);
-		obj = new Data();
-		obj.setTitle("hotmail");
-		obj.setContent(
-				"Get free Outlook email and calendar, plus Office Online apps like Word, Excel and PowerPoint. Sign in to access your Outlook, Hotmail or Live email account.");
-		obj.setUrl("https://outlook.live.com/owa/");
-		searchResponse.add(obj);
+		searchResponse.add(new Data("google",
+				"Search the world's information, including webpages, images, videos and more. Google has many special features to help you find exactly what you're looking",
+				"www.google.com"));
+
+		searchResponse.add(new Data("google",
+				"Discover all the latest about our products, technology, and Google culture on our official blog.",
+				"https://about.google.com"));
+
+		searchResponse.add(new Data("facebook",
+				"Create an account or log into Facebook. Connect with friends, family and other people you know. Share photos and videos, send messages and get updates.",
+				"https://www.facebook.com/"));
+
+		searchResponse.add(new Data("whatsapp web",
+				"Quickly send and receive WhatsApp messages right from your computer", "https://web.whatsapp.com/"));
+
+		searchResponse.add(new Data("youtube",
+				"Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.",
+				"https://www.youtube.com/"));
 
 		return searchResponse;
 	}

--- a/src/main/java/com/gsearch/dto/Data.java
+++ b/src/main/java/com/gsearch/dto/Data.java
@@ -9,4 +9,9 @@ public class Data {
 
 	private String url;
 
+	public Data(String title, String content, String url) {
+		this.title = title;
+		this.content = content;
+		this.url = url;
+	}
 }


### PR DESCRIPTION
## Issue ID
#18 
## Summary
Return list of results content instead of an object
## Checklist

- [x] Have you added an summary of what your changes do and why you'd like us to include them?
- [x] Which changes caused this issue / Root Cause.
  - _link issue here_
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the current behavior, and the steps to reproduce the issue?
Currently API returns only one result even tough there are many results matched for the given search query. 
### What is the expected behavior?
API should return list of results for the given search term.
### How does this PR fix the problem, Screenshot Please?

![image](https://user-images.githubusercontent.com/4453880/157854865-5bdb1f67-80e0-4df0-b3e0-4e442345f8db.png)
